### PR TITLE
doc: add missing `install` subcommand for brew command to install the plugin

### DIFF
--- a/aws/README.adoc
+++ b/aws/README.adoc
@@ -16,7 +16,7 @@ You can install the pre-compiled binary or compile from source.
 # install tap repository once
 brew tap deviceinsight/packages
 # install
-brew kafkactl-aws-plugin
+brew install kafkactl-aws-plugin
 # upgrade
 brew upgrade kafkactl-aws-plugin
 ----

--- a/azure/README.adoc
+++ b/azure/README.adoc
@@ -16,7 +16,7 @@ You can install the pre-compiled binary or compile from source.
 # install tap repostory once
 brew tap deviceinsight/packages
 # install
-brew kafkactl-azure-plugin
+brew install kafkactl-azure-plugin
 # upgrade
 brew upgrade kafkactl-azure-plugin
 ----


### PR DESCRIPTION
# Description

`brew install <PLUGIN>` is the correct command. Without `install` it will run into an error:

```
Error: Unknown command: brew kafkactl-azure-plugin
```

Fixes # None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `<plugin>/CHANGELOG.md`
- [ ] the configuration options in `<plugin>/README.adoc` were updated
