### PR TITLE
fix: ensure proper copying of plugins in Dockerfiles

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
 Update dependencies
+
+Fix docker container build
 
 ## 1.2.0 - 2024-11-28
 

--- a/aws/Dockerfile.Scratch
+++ b/aws/Dockerfile.Scratch
@@ -1,4 +1,6 @@
 ARG KAFKACTL_VERSION
 FROM deviceinsight/kafkactl:${KAFKACTL_VERSION}-scratch
-COPY kafkactl-aws-plugin /usr/local/bin
+WORKDIR /tmp/
+WORKDIR /
+COPY kafkactl-aws-plugin /usr/local/bin/
 ENTRYPOINT ["/kafkactl"]

--- a/aws/Dockerfile.Ubuntu
+++ b/aws/Dockerfile.Ubuntu
@@ -1,4 +1,4 @@
 ARG KAFKACTL_VERSION
 FROM deviceinsight/kafkactl:${KAFKACTL_VERSION}-ubuntu
-COPY kafkactl-aws-plugin /usr/local/bin
+COPY kafkactl-aws-plugin /usr/local/bin/
 ENTRYPOINT ["/kafkactl"]

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Fix docker container build
+
 ## 1.2.0 - 2024-11-28
 
 ### Fixed

--- a/azure/Dockerfile.Scratch
+++ b/azure/Dockerfile.Scratch
@@ -1,4 +1,6 @@
 ARG KAFKACTL_VERSION
 FROM deviceinsight/kafkactl:${KAFKACTL_VERSION}-scratch
-COPY kafkactl-azure-plugin /usr/local/bin
+WORKDIR /tmp/
+WORKDIR /
+COPY kafkactl-azure-plugin /usr/local/bin/
 ENTRYPOINT ["/kafkactl"]

--- a/azure/Dockerfile.Ubuntu
+++ b/azure/Dockerfile.Ubuntu
@@ -1,4 +1,4 @@
 ARG KAFKACTL_VERSION
 FROM deviceinsight/kafkactl:${KAFKACTL_VERSION}-ubuntu
-COPY kafkactl-azure-plugin /usr/local/bin
+COPY kafkactl-azure-plugin /usr/local/bin/
 ENTRYPOINT ["/kafkactl"]


### PR DESCRIPTION
# Description

Currently the `kafkactl-aws/azure-plugin` binaries end up as `/usr/local/bin` (a file named `bin` in `/usr/local/`).

Also in the `scratch` flavoured builds the `/tmp` directory is missing. At least for the Azure plugin its definitely needed. I'm not sure about AWS but it can't hurt to create it there either.

I'm using `WORKDIR` to create the directories because there is no `mkdir` to use in the scratch images.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `<plugin>/CHANGELOG.md`

