### PR TITLE
feat: add support setting a custom client-id when using workload identity based auth

### DIFF
--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+Add `client-id` option for workload identity authentication
+
 ## 1.2.0 - 2024-11-28
 
 ### Fixed

--- a/azure/README.adoc
+++ b/azure/README.adoc
@@ -102,7 +102,11 @@ contexts:
 
 |tenant-id
 |string
-|configure a fixed tenant
+|configure a fixed tenant for Azure CLI and workload identity authentication
+
+|client-id
+|string
+|configure a fixed client id for workload identity authentication
 
 |verbose
 |boolean

--- a/azure/main.go
+++ b/azure/main.go
@@ -58,6 +58,11 @@ func (t *tokenProvider) Init(options map[string]any, brokers []string) (err erro
 		tenantID = ""
 	}
 
+	clientID, ok := options["client-id"].(string)
+	if ok {
+		_ = os.Setenv("AZURE_CLIENT_ID", clientID)
+	}
+
 	t.tokenAudience = fmt.Sprintf("%s://%s/.default", eventhubURL.Scheme, eventhubURL.Hostname())
 
 	credential, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{


### PR DESCRIPTION
# Description

Add the option to provide a custom `client-id` when using workload identity based authentication. Since the `DefaultAzureCredentialOptions` is not providing an option to do this, use the `AZURE_CLIENT_ID` environment variable.

This environment variable is then evaluated by the `WorkloadIdentityCredential`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `<plugin>/CHANGELOG.md`
- [x] the configuration options in `<plugin>/README.adoc` were updated
